### PR TITLE
[TECH] Migrer vers Powerpipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ Use with [Scalingo][]: `scalingo env-set BUILDPACK_URL=https://github.com/franco
 
 ## Procfile
 
-**With dashboard**:
-
-```
-web: ./bin/steampipe dashboard --dashboard-port $PORT --dashboard-listen network
-```
-
 **Raw access to the postgres**
 
 Add the [tcp addon](https://doc.scalingo.com/addons/tcp-gateway/start).

--- a/bin/compile
+++ b/bin/compile
@@ -65,7 +65,3 @@ echo "Installing config"
 mkdir -p $BUILD_DIR/.steampipe/config
 find $BUILD_DIR -name "*.spc.erb" -exec bash -c "erb {} > $BUILD_DIR/.steampipe/config/\$(basename {} .erb)" \;
 echo "Successfully configured"
-
-echo "Installing mod dependencies"
-cd $BUILD_DIR && STEAMPIPE_INSTALL_DIR=$BUILD_DIR/.steampipe $bin_dir/steampipe mod install
-echo "Successfully installed mod dependencies"


### PR DESCRIPTION
## :unicorn: Problème
Steampipe se scinde en plusieurs solutions, notamment Powerpipe pour la gestion des mods et des dashboard. Ainsi, il ne revient plus au buildpack de steampipe d'installer les mods mais au buildpack de powerpipe.

## :robot: Proposition
- Supprimer l'installation des mods du buildpack
- Mettre à jour le README